### PR TITLE
upgrade from old excon version

### DIFF
--- a/lib/lightspeed_restaurant/version.rb
+++ b/lib/lightspeed_restaurant/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LightspeedRestaurantClient
-  VERSION = '1.1.3'
+  VERSION = '1.1.4'
 end

--- a/lightspeed_restaurant.gemspec
+++ b/lightspeed_restaurant.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency('excon', '~> 0.45.4')
+  spec.add_dependency('excon', '~> 0.62.0')
   spec.add_dependency('json', '~> 1.8.3')
 
   spec.add_development_dependency('bundler-audit')


### PR DESCRIPTION
The idea behind is trying to fix our random `SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A: sslv3 alert handshake failure (OpenSSL::SSL::SSLError)`