### PR TITLE
Allow GET requests to receive a specific read_timeout

### DIFF
--- a/lib/lightspeed_restaurant.rb
+++ b/lib/lightspeed_restaurant.rb
@@ -28,8 +28,8 @@ module LightspeedRestaurantClient
       Configuration.new(@api_token, @base_uri)
     end
 
-    def get(path, query = {}, configuration = nil)
-      request(path, {}, query, configuration).perform(method: :get)
+    def get(path, query = {}, configuration = nil, read_timeout: nil)
+      request(path, {}, query, configuration).perform(method: :get, read_timeout: read_timeout)
     end
 
     def post(path, body = {}, query = {}, configuration = nil)

--- a/lib/lightspeed_restaurant/operations/find.rb
+++ b/lib/lightspeed_restaurant/operations/find.rb
@@ -3,8 +3,11 @@
 module LightspeedRestaurantClient
   module Operations
     module Find
-      def find(id, configuration = nil)
-        response = JSON.parse(LightspeedRestaurantClient.get(default_resource_path + "/#{id}", {}, configuration))
+      def find(id, configuration = nil, read_timeout: nil)
+        path = "#{default_resource_path}/#{id}"
+        response = JSON.parse(
+          LightspeedRestaurantClient.get(path, {}, configuration, read_timeout)
+        )
         new(response)
       end
     end

--- a/lib/lightspeed_restaurant/operations/list.rb
+++ b/lib/lightspeed_restaurant/operations/list.rb
@@ -3,8 +3,10 @@
 module LightspeedRestaurantClient
   module Operations
     module List
-      def list(params = {}, configuration = nil)
-        response = JSON.parse(LightspeedRestaurantClient.get(resource_path, params, configuration))
+      def list(params = {}, configuration = nil, read_timeout: nil)
+        response = JSON.parse(
+          LightspeedRestaurantClient.get(resource_path, params, configuration, read_timeout)
+        )
         response = handle_list_response(response)
         instantiate(response)
       end


### PR DESCRIPTION
This PR makes the method `LightspeedRestaurantClient.get` accept an optional `read_timeout`.

It also exposes this option in the `List` and `Find` module, so one can use the following in case a specific resource has a longer fetch time.

```
LightspeedRestaurantClient::Receipt.all(params, api_config, read_timeout: 120)
# and
LightspeedRestaurantClient::Receipt.find(id, api_config, read_timeout: 120)
```

Default timeout is Excon's default: 60 seconds ([source](https://github.com/excon/excon/blob/6277f48da7f3a6f0717248455f8761ef2a7679da/lib/excon/constants.rb#L157))