### PR TITLE
Golf 4451 fix resto sync

### DIFF
--- a/lib/lightspeed_restaurant/product_group_product.rb
+++ b/lib/lightspeed_restaurant/product_group_product.rb
@@ -6,6 +6,7 @@ require 'lightspeed_restaurant/operations/create'
 module LightspeedRestaurantClient
   class ProductGroupProduct < LightspeedRestaurantClient::Base
     include Operations::Create
+    include Operations::List
 
     def initialize(product_group_id)
       super

--- a/lightspeed_restaurant.gemspec
+++ b/lightspeed_restaurant.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency('excon', '~> 0.71.0')
-  spec.add_dependency('json', '~> 2.3')
+  spec.add_dependency('excon', '~> 0.91.0')
+  spec.add_dependency('json', '~> 2.6.1')
 
   spec.add_development_dependency('pry')
   spec.add_development_dependency('rake')

--- a/spec/fixtures/vcr_cassettes/product/list.yml
+++ b/spec/fixtures/vcr_cassettes/product/list.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://staging-integration.posios.com/PosServer/rest/inventory/productgroup/57137/product
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Content-Type:
+      - application/json
+      X-Auth-Token:
+      - API_TOKEN_VALUE
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 03 Apr 2019 18:46:47 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '747'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d6da75032e01113428857de6a159f1f1c1554317207; expires=Thu, 02-Apr-20
+        18:46:47 GMT; path=/; domain=.posios.com; HttpOnly
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - POST, PUT, PATCH, GET, OPTIONS, DELETE
+      Access-Control-Max-Age:
+      - '3600'
+      Access-Control-Allow-Headers:
+      - x-auth-token, x-requested-with, content-type
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4c1d35126d3e9272-EWR
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":57134},{"id":57135},{"id":57136},{"id":57137},{"id":59109},{"id":62306}]'
+    http_version: 
+  recorded_at: Wed, 03 Apr 2019 18:46:47 GMT
+recorded_with: VCR 4.0.0

--- a/spec/lightspeed_restaurant/product_group_product_spec.rb
+++ b/spec/lightspeed_restaurant/product_group_product_spec.rb
@@ -8,11 +8,11 @@ module LightspeedRestaurantClient
 
     let(:resource_name) { 'product' }
     let(:fake_logger) { FakeLogger.new }
+    let(:resource_params) { { product_group_id: 57137 } }
 
     before { LightspeedRestaurantClient.logger = fake_logger }
 
     context 'when creating' do
-      let(:resource_params) { { product_group_id: 57137 } }
       let(:valid_params)    do
         {
           deliveryPrice: 0,
@@ -40,6 +40,16 @@ module LightspeedRestaurantClient
         VCR.use_cassette("#{resource_name}/create", allow_playback_repeats: true) do
           resource = described_class.new(resource_params).create(valid_params)
           expect(resource.id).to eq 154141
+        end
+      end
+    end
+
+    context "when listing" do
+      it 'lists the products in the group' do
+        VCR.use_cassette("#{resource_name}/list", allow_playback_repeats: true) do
+          products = described_class.new(resource_params).list({})
+          expect(products.length).to eq 6
+          expect(products.first.id).to eq 57134
         end
       end
     end


### PR DESCRIPTION
Add listing capability for products.

This change is required in order to fix the restaurant sync issue. We need to check if the chronogolf product exists in resto.